### PR TITLE
modified tcjudge

### DIFF
--- a/tcjudge
+++ b/tcjudge
@@ -957,9 +957,9 @@ EOS
       open(@tester_source_name, 'w') {|f| f.write perform_cut(code) + generate_tester() }
 
       if File.basename(compiler, '.exe').downcase == 'csc'
-        @compile_options = "#{compiler} #{@tester_source_name} /out:\"#{@tester_name}\""
+        @compile_options = "#{compiler} /r:System.Numerics.dll #{@tester_source_name} /out:\"#{@tester_name}\""
       else
-        @compile_options = "#{compiler} #{@tester_source_name} -out:\"#{@tester_name}\""
+        @compile_options = "#{compiler} /r:System.Numerics.dll #{@tester_source_name} -out:\"#{@tester_name}\""
       end
       puts @compile_options
       unless system(@compile_options)


### PR DESCRIPTION
add reference "System.Numerics.dll" to tcjudge C# compile options
The classes included in System.Numerics.dll can be used in arena.
